### PR TITLE
Added as_pure_dictionary method

### DIFF
--- a/UltraDict.py
+++ b/UltraDict.py
@@ -1103,6 +1103,19 @@ class UltraDict(collections.UserDict, dict):
                 raise e
         return False
 
+    @classmethod
+    def as_pure_dictionary(cls, to_convert=None):
+        if to_convert is None:
+            to_convert = cls
+        
+        if isinstance(to_convert, UltraDict):
+            res = dict(to_convert)
+            for key in res.keys():
+                res[key] = cls.as_pure_dictionary(res[key])
+
+            return res
+        
+        return to_convert
 
 
 # Saved as a reference

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -179,6 +179,58 @@ class UltraDictTests(unittest.TestCase):
         self.assertEqual(ret.stdout.splitlines()[-1], b"Counter: 100 == 100", self.exec_show_output(ret))
 
 
+    def test_export_as_pure_dict(self):
+        ultra = UltraDict(
+            {
+                "1": "hello",
+                "2": 5,
+                "3": {
+                    "1": 1,
+                    "2": {
+                        "1": True,
+                        "2": None,
+                        "3": [1, 2, 3]
+                    },
+                    "3": [4, 5, 6, {"7": 8}]
+                }
+            },
+            recurse=True
+        )
+
+        ultra2 = UltraDict(
+            {
+                "1": "hello",
+                "2": 5,
+                "3": {
+                    "1": 1,
+                    "2": {
+                        "1": True,
+                        "2": None,
+                        "3": [1, 2, 3]
+                    },
+                    "3": [4, 5, 6, {"7": 8}]
+                }
+            },
+            recurse=False
+        )
+
+
+        def assert_pure_dict(elem):
+            self.assertNotIsInstance(elem, UltraDict)
+
+            if isinstance(elem, dict):
+                for key in elem.keys():
+                    assert_pure_dict(elem[key])
+
+        
+        with self.assertRaises(AssertionError):
+            assert_pure_dict(ultra)
+            assert_pure_dict(ultra2)
+
+        assert_pure_dict(ultra.as_pure_dictionary())
+        assert_pure_dict(ultra2.as_pure_dictionary())
+
+
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         for i in range(0, len(sys.argv)):


### PR DESCRIPTION
I recently had a problem with pickling and unpickling UltraDict instances with recurse=True.
After some wild bug hunting I realized that accessing UltraDict's data attribute/property didn't convert nested UltraDict items also to basic dictionaries, thus breaking pickling and unpickling actions, other than stopping following updates from syncing.

I added the method `as_pure_dictionary`, with proper unit tests, and tested them in production with one single shared memory between 6 high frequency realtime processes both using reads and writes in different parts of the same UltraDict with recurse=True enabled, with success!

Basic usage for me in that project was something like this pseudocode:

```python
ultra = UltraDict(
    {
        "1": "hello",
        "2": 5,
        "3": {
            "1": 1,
            "2": {
                "1": True,
                "2": None,
                "3": [1, 2, 3]
            },
            "3": [4, 5, 6, {"7": 8}]
        }
    },
    recurse=True,
    create=True
)

as_dict = ultra.as_pure_dictionary()
db.save(pickle.dumps(as_dict))
# Saving it to database

# Some time later, on the next app opening
as_dict = pickle.loads(db.load())
ultra = UltraDict(as_dict, recurse=True, create=True)

# And start reusing it as I left it!
ultra["2"] = 18
```

Hope it sounds good for you, and hope it helps somebody as well as it helped me!

If you have questions let me know, I'm happy to fix things if they aren't properly good enough :)